### PR TITLE
undefined access in local settings

### DIFF
--- a/3. Batch Computational Pattern/NotifyContainer/server.js
+++ b/3. Batch Computational Pattern/NotifyContainer/server.js
@@ -5,7 +5,10 @@
 const express = require('express');
 const nodemailer = require('nodemailer');
 var localSettings = require('./local.settings');
-localSettings.connectionStrings.eventHub = process.env.EVENT_HUB_CONNECTION_STRING;
+
+localSettings.connectionStrings = {
+    eventHub : process.env.EVENT_HUB_CONNECTION_STRING
+};
 
 console.log('localSettings = ' + JSON.stringify(localSettings));
 


### PR DESCRIPTION
Wrong _local.settings.json_ objects access fields cause crashing notify pod

`localSettings.connectionStrings.eventHub = process.env.EVENT_HUB_CONNECTION_STRING;
                                         ^
TypeError: Cannot set property 'eventHub' of undefined`
