### PR TITLE
Corrects spelling

### DIFF
--- a/3. Batch Computational Pattern/PrepareContainer/prepare-deployment.yaml
+++ b/3. Batch Computational Pattern/PrepareContainer/prepare-deployment.yaml
@@ -10,7 +10,7 @@ spec:
         app: prepare-deployment
     spec:
       containers:
-      - name: prepare-depoyment
+      - name: prepare-deployment
         image: batchprocessingthumbnailgeneratorregistry.azurecr.io/batchprocessing-prepare
         ports:
         - containerPort: 8080

--- a/3. Batch Computational Pattern/README.md
+++ b/3. Batch Computational Pattern/README.md
@@ -426,7 +426,7 @@ Now you have a private Docker image with tag ```batchprocessingthumbnailgenerato
             app: prepare-deployment
         spec:
           containers:
-          - name: prepare-depoyment
+          - name: prepare-deployment
             image: batchprocessingthumbnailgeneratorregistry.azurecr.io/batchprocessing-prepare
             ports:
             - containerPort: 8080


### PR DESCRIPTION
Updated YAML and README to correct spelling of "deployment" in the container name. No functional need to do so, but I found it distracting when reviewing the lab